### PR TITLE
[Docker] Pin Kafka version to 2.5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: 'bitnami/kafka:latest'
+    image: 'bitnami/kafka:2.5.0'
     environment:
       - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT,INTERNAL:PLAINTEXT


### PR DESCRIPTION
There are some breaking changes in Kafka 3.0.0 that conflict with the `docker-compose.yml` setup.

For example, `kafka-topics.sh` can no longer take `--zookeeper` as an argument, instead it must take ` "--bootstrap-server` (https://issues.apache.org/jira/browse/KAFKA-9397)

I've pinned version 2.5.0 which is the latest release still supporting this argument.