### PR TITLE
Add elasticsearch to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,10 @@ optionally supply `--build-arg PORT=8001` to the build stage to change its port,
 docker build -t nglp-analytics .
 docker run -it -p 8000:8000 --name nglp-analytics nglp-analytics
 ```
+
+### Starting app with docker-compose
+You can run a stack of kafka+zookeper together with the analytics services with `docker-compose run`. You will still need to configure your .env file as per the instructions above, pointing to the instance of ElasticSearch to connect to.
+
+Alternatively, you can also feed in the `docker-compose-es.yml` file to spin up a dockerised instance of ElasticSearch (Open Distro's release). There is a custom `.env` file setup for this docker-compose setup (`env.docker`), so all you need to do is run the following:
+
+`docker-compose -f docker-compose.yml -f docker-compose-es.yml up`

--- a/docker-compose-es.yml
+++ b/docker-compose-es.yml
@@ -32,3 +32,19 @@ services:
     restart: on-failure
     volumes:
       - ${PWD}/:/app
+
+  kafka:
+    environment:
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9103,EXTERNAL://kafka:9092,,INTERNAL://kafka:19092
+
+  nglp-events-consumer:
+    env_file: env.docker
+    restart: on-failure
+    volumes:
+      - ${PWD}/:/app
+
+  nglp-oids-consumer:
+    env_file: env.docker
+    restart: on-failure
+    volumes:
+      - ${PWD}/:/app

--- a/docker-compose-es.yml
+++ b/docker-compose-es.yml
@@ -1,0 +1,23 @@
+version: '2.4'
+services:
+  elasticsearch:
+    image: amazon/opendistro-for-elasticsearch:1.13.3
+    environment:
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65535
+        hard: 65535
+    ports:
+      - 9200:9200
+      - 9600:9600 # required for Performance Analyzer
+    healthcheck:
+      test: ["CMD", "curl", "-XGET", "https://localhost:9200", "-u", "admin:admin", "--insecure"]
+      interval: 5s
+      timeout: 10s
+      retries: 5

--- a/docker-compose-es.yml
+++ b/docker-compose-es.yml
@@ -21,3 +21,14 @@ services:
       interval: 5s
       timeout: 10s
       retries: 5
+
+  analytics:
+    env_file: env.docker
+    depends_on:
+      kafka:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    restart: on-failure
+    volumes:
+      - ${PWD}/:/app

--- a/env.docker
+++ b/env.docker
@@ -1,0 +1,12 @@
+# Save this file as .env in the project root
+host = "0.0.0.0"
+port = "8000"
+
+# ES hosts can contain basic auth credentials, such as http://user:secret@localhost:9200/
+# if you are using opendistro elasticsearch, then these settings should work out of the box
+es_hosts = ["https://admin:admin@elasticsearch:9200"]
+es_verify_certs = False
+kafka_broker = "kafka"
+
+# GeoLite City database for GeoIP
+#geo_database=/path/to/geolite2.mmdb


### PR DESCRIPTION
I've added a single-node to a separate docker-compose for folks who would like to run all the dependencies in docker containers.

I've also added a new `.env` file with the configuration required to run the docker-compose stack without having to create your own (`env.docker`)

As a result, the whole stack can be spinned with just ` docker-compose -f docker-compose.yml -f docker-compose-es.yml up` without the need to configure anything. Granted, the end result is an empty analytics dashboard, but from there your sample data can be loaded in with a `docker exec nglp-analytics_analytics_1` command

The `docker-compose-es.yml` file also makes a few overrides on your services to mount the local working copy of the app code, which helps with development.


Nevertheless, this PR depends on #69 to work

